### PR TITLE
Fix LongRoPE KV Cache

### DIFF
--- a/vllm/attention/backends/abstract.py
+++ b/vllm/attention/backends/abstract.py
@@ -86,6 +86,7 @@ class AttentionMetadata(Generic[T]):
     slot_mapping: torch.Tensor
     # The kv cache's data type.
     kv_cache_dtype: str
+    max_seq_tokens_tensor: torch.Tensor
 
     def __post_init__(self):
         if self.num_prefill_tokens > 0:

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -71,7 +71,7 @@ class FlashAttentionMetadata(AttentionMetadataPerStage,
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
-    max_seq_tokens_list: Optional[List[int]]
+    max_seq_tokens_tensor: torch.Tensor
 
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|

--- a/vllm/attention/backends/flash_attn.py
+++ b/vllm/attention/backends/flash_attn.py
@@ -71,6 +71,8 @@ class FlashAttentionMetadata(AttentionMetadataPerStage,
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
+    max_seq_tokens_list: Optional[List[int]]
+
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|
     # |---------------- N iteration ---------------------|

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -69,7 +69,7 @@ class ROCmFlashAttentionMetadata(AttentionMetadataPerStage,
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
-    max_seq_tokens_list: Optional[List[int]]
+    max_seq_tokens_tensor: torch.Tensor
 
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|

--- a/vllm/attention/backends/rocm_flash_attn.py
+++ b/vllm/attention/backends/rocm_flash_attn.py
@@ -69,6 +69,8 @@ class ROCmFlashAttentionMetadata(AttentionMetadataPerStage,
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
+    max_seq_tokens_list: Optional[List[int]]
+
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|
     # |---------------- N iteration ---------------------|

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -59,6 +59,7 @@ class TorchSDPAMetadata(AttentionMetadata, PagedAttentionMetadata,
     is_prompt: bool
     slot_mapping: torch.Tensor
     prompt_lens: Optional[List[int]]
+    max_seq_tokens_list: Optional[List[int]]
 
     def __post_init__(self):
         # Set during the execution of the first attention op.

--- a/vllm/attention/backends/torch_sdpa.py
+++ b/vllm/attention/backends/torch_sdpa.py
@@ -59,7 +59,7 @@ class TorchSDPAMetadata(AttentionMetadata, PagedAttentionMetadata,
     is_prompt: bool
     slot_mapping: torch.Tensor
     prompt_lens: Optional[List[int]]
-    max_seq_tokens_list: Optional[List[int]]
+    max_seq_tokens_tensor: torch.Tensor
 
     def __post_init__(self):
         # Set during the execution of the first attention op.

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -71,7 +71,7 @@ class XFormersMetadata(AttentionMetadataPerStage, PagedAttentionMetadata):
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
-    max_seq_tokens_list: Optional[List[int]]
+    max_seq_tokens_tensor: torch.Tensor
 
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|

--- a/vllm/attention/backends/xformers.py
+++ b/vllm/attention/backends/xformers.py
@@ -71,6 +71,8 @@ class XFormersMetadata(AttentionMetadataPerStage, PagedAttentionMetadata):
     # prompt_lens stored as a tensor.
     prompt_lens_tensor: Optional[torch.Tensor]
 
+    max_seq_tokens_list: Optional[List[int]]
+
     # NOTE(sang): Definition of context_len, subquery_len, and seqlen.
     # |---------- N-1 iteration --------|
     # |---------------- N iteration ---------------------|

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -429,7 +429,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         key = key.view(*key.shape[:-1], -1, self.head_size)
 
         k = self.original_max_position_embeddings
-        if max_seq_tokens_list is None:
+        if max_seq_tokens_list is None or len(max_seq_tokens_list) == 0:
             long_prompt_offset = (torch.any(positions > k).float() *
                                 torch.full_like(positions, k)).long()
         else:

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -431,6 +431,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         k = self.original_max_position_embeddings
         long_prompt_offset_0 = (torch.any(positions > k).float() * torch.full_like(positions, k)).long()
         long_prompt_offset_1 = torch.where(max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor), torch.full_like(max_seq_tokens_tensor, k))
+        print(f"max_seq_tokens_tensor: {max_seq_tokens_tensor}")
         long_prompt_offset = torch.where(max_seq_tokens_tensor < 0, long_prompt_offset_0, long_prompt_offset_1)
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -433,7 +433,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
             long_prompt_offset = (torch.any(positions > k).float() *
                                 torch.full_like(positions, k)).long()
         else:
-            max_seq_tokens_tensor = torch.tensor(max_seq_tokens_list).to(long_prompt_offset.device)
+            max_seq_tokens_tensor = torch.tensor(max_seq_tokens_list).to(positions.device)
             long_prompt_offset = torch.where(
                 max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor),
                 torch.full_like(max_seq_tokens_tensor, k))

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -433,7 +433,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
             long_prompt_offset = (torch.any(positions > k).float() *
                                 torch.full_like(positions, k)).long()
         else:
-            max_seq_tokens_tensor = torch.tensor(max_seq_tokens_list)
+            max_seq_tokens_tensor = torch.tensor(max_seq_tokens_list).to(long_prompt_offset.device)
             long_prompt_offset = torch.where(
                 max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor),
                 torch.full_like(max_seq_tokens_tensor, k))

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -431,7 +431,6 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         k = self.original_max_position_embeddings
         long_prompt_offset_0 = (torch.any(positions > k).float() * torch.full_like(positions, k)).long()
         long_prompt_offset_1 = torch.where(max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor), torch.full_like(max_seq_tokens_tensor, k))
-        # print(f"max_seq_tokens_tensor[0]: {max_seq_tokens_tensor[0]}")
         long_prompt_offset = torch.where(max_seq_tokens_tensor < 0, long_prompt_offset_0, long_prompt_offset_1)
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -431,7 +431,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         k = self.original_max_position_embeddings
         long_prompt_offset_0 = (torch.any(positions > k).float() * torch.full_like(positions, k)).long()
         long_prompt_offset_1 = torch.where(max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor), torch.full_like(max_seq_tokens_tensor, k))
-        print(f"max_seq_tokens_tensor: {max_seq_tokens_tensor}")
+        print(f"max_seq_tokens_tensor[0]: {max_seq_tokens_tensor[0]}")
         long_prompt_offset = torch.where(max_seq_tokens_tensor < 0, long_prompt_offset_0, long_prompt_offset_1)
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)

--- a/vllm/model_executor/layers/rotary_embedding.py
+++ b/vllm/model_executor/layers/rotary_embedding.py
@@ -431,7 +431,7 @@ class Phi3LongRoPEScaledRotaryEmbedding(nn.Module):
         k = self.original_max_position_embeddings
         long_prompt_offset_0 = (torch.any(positions > k).float() * torch.full_like(positions, k)).long()
         long_prompt_offset_1 = torch.where(max_seq_tokens_tensor <= k, torch.zeros_like(max_seq_tokens_tensor), torch.full_like(max_seq_tokens_tensor, k))
-        print(f"max_seq_tokens_tensor[0]: {max_seq_tokens_tensor[0]}")
+        # print(f"max_seq_tokens_tensor[0]: {max_seq_tokens_tensor[0]}")
         long_prompt_offset = torch.where(max_seq_tokens_tensor < 0, long_prompt_offset_0, long_prompt_offset_1)
         idx = (torch.add(positions, long_prompt_offset)
                if long_prompt_offset is not None else positions)

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -36,7 +36,8 @@ _MODELS = {
     # For decapoda-research/llama-*
     "LLaMAForCausalLM": ("llama", "LlamaForCausalLM"),
     "MistralForCausalLM": ("llama", "LlamaForCausalLM"),
-    "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"), ##
+    # "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"), ##
+    "MixtralForCausalLM": ("phimoe", "PhiMoEForCausalLM"),
     "QuantMixtralForCausalLM": ("mixtral_quant", "MixtralForCausalLM"),
     "PhiMoEForCausalLM": ("phimoe", "PhiMoEForCausalLM"),
     # transformers's mpt class has lower case

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -36,8 +36,8 @@ _MODELS = {
     # For decapoda-research/llama-*
     "LLaMAForCausalLM": ("llama", "LlamaForCausalLM"),
     "MistralForCausalLM": ("llama", "LlamaForCausalLM"),
-    # "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"), ##
-    "MixtralForCausalLM": ("phimoe", "PhiMoEForCausalLM"),
+    "MixtralForCausalLM": ("mixtral", "MixtralForCausalLM"), ##
+    # "MixtralForCausalLM": ("phimoe", "PhiMoEForCausalLM"),
     "QuantMixtralForCausalLM": ("mixtral_quant", "MixtralForCausalLM"),
     "PhiMoEForCausalLM": ("phimoe", "PhiMoEForCausalLM"),
     # transformers's mpt class has lower case

--- a/vllm/model_executor/models/__init__.py
+++ b/vllm/model_executor/models/__init__.py
@@ -48,6 +48,7 @@ _MODELS = {
     "OrionForCausalLM": ("orion", "OrionForCausalLM"),
     "PhiForCausalLM": ("phi", "PhiForCausalLM"),
     "Phi3ForCausalLM": ("llama", "LlamaForCausalLM"),
+    "PhiLongRoPEForCausalLM": ("llama", "LlamaForCausalLM"),
     "QWenLMHeadModel": ("qwen", "QWenLMHeadModel"),
     "Qwen2ForCausalLM": ("qwen2", "Qwen2ForCausalLM"),
     "Qwen2MoeForCausalLM": ("qwen2_moe", "Qwen2MoeForCausalLM"),

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -163,12 +163,7 @@ class LlamaAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        max_seq_tokens_list = []
-        if attn_metadata.prefill_metadata is not None:
-            max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
-        if attn_metadata.decode_metadata is not None:
-            max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_list)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=max_seq_tokens_tensor)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata,
                                 self.kv_scale)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -164,8 +164,10 @@ class LlamaAttention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         max_seq_tokens_list = []
-        max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
-        max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
+        if attn_metadata.prefill_metadata is not None:
+            max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
+        if attn_metadata.decode_metadata is not None:
+            max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
         q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_list)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata,
                                 self.kv_scale)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -163,7 +163,10 @@ class LlamaAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=attn_metadata.max_seq_tokens_list)
+        max_seq_tokens_list = []
+        max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
+        max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_list)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata,
                                 self.kv_scale)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -163,7 +163,7 @@ class LlamaAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self.rotary_emb(positions, q, k)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=attn_metadata.max_seq_tokens_list)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata,
                                 self.kv_scale)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -163,7 +163,7 @@ class LlamaAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=max_seq_tokens_tensor)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=attn_metadata.max_seq_tokens_tensor)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata,
                                 self.kv_scale)
         output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -133,6 +133,45 @@ class PhiMoEConfig(PretrainedConfig):
             **kwargs,
         )
 
+class mp(torch.autograd.Function):
+
+    @staticmethod
+    def forward(
+        ctx, 
+        scores: torch.Tensor, 
+        multiplier: torch.Tensor, 
+        selected_experts: torch.Tensor,
+        masked_gates: torch.Tensor,
+        mask_for_one: torch.Tensor,
+    ):
+        ctx.save_for_backward(multiplier, selected_experts, masked_gates)
+        return multiplier * mask_for_one
+ 
+    @staticmethod
+    def backward(
+        ctx, 
+        grad_at_output: torch.Tensor, 
+    ):
+        multiplier, selected_experts, masked_gates = ctx.saved_tensors
+
+        grad_at_output = grad_at_output * multiplier
+
+        grad_at_scores_expaned = masked_gates * grad_at_output.mul(-1)
+        grad_at_scores_expaned.scatter_add_(
+            dim=-1,
+            index=selected_experts,
+            src=grad_at_output,
+        )
+
+        return (
+            grad_at_scores_expaned, 
+            None, 
+            None, 
+            None, 
+            None, 
+        )
+
+
 def sparsemixer(scores, top_k, jitter_eps=0.01):
     assert top_k == 2
     

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -436,7 +436,12 @@ class PhiMoEAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        q, k = self.rotary_emb(positions, q, k)
+        max_seq_tokens_list = []
+        if attn_metadata.prefill_metadata is not None:
+            max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
+        if attn_metadata.decode_metadata is not None:
+            max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_list)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -445,12 +445,8 @@ class PhiMoEAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        max_seq_tokens_list = []
-        if attn_metadata.prefill_metadata is not None:
-            max_seq_tokens_list.extend(attn_metadata.prefill_metadata.max_seq_tokens_list)
-        if attn_metadata.decode_metadata is not None:
-            max_seq_tokens_list.extend(attn_metadata.decode_metadata.max_seq_tokens_list)
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_list)
+        max_seq_tokens_tensor = torch.cat([attn_metadata.prefill_metadata.max_seq_tokens_tensor, attn_metadata.decode_metadata.max_seq_tokens_tensor], dim=0)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_tensor)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -445,8 +445,8 @@ class PhiMoEAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        max_seq_tokens_tensor = torch.cat([attn_metadata.prefill_metadata.max_seq_tokens_tensor, attn_metadata.decode_metadata.max_seq_tokens_tensor], dim=0)
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_list=max_seq_tokens_tensor)
+        max_seq_tokens_tensor = attn_metadata.max_seq_tokens_tensor
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=max_seq_tokens_tensor)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -133,45 +133,54 @@ class PhiMoEConfig(PretrainedConfig):
             **kwargs,
         )
 
-def sparsemixer(scores, top_k, jitter_eps=0.1):
+def sparsemixer(scores, top_k, jitter_eps=0.01):
     assert top_k == 2
+    
+    ################ first expert ################
+    
+    with torch.no_grad():
+        # compute mask for sparsity
+        mask_logits_threshold, max_ind = scores.max(dim=-1, keepdim=True)
+        factor = scores.abs().clamp(min=mask_logits_threshold)
+        mask_logits_threshold = (
+            (mask_logits_threshold - scores) / factor
+        ) > (2 * jitter_eps)
 
-    ################ routing ################
+    # apply mask 
+    masked_gates = scores.masked_fill(mask_logits_threshold, float('-inf'))
+    selected_experts = max_ind
+        
+    # compute scores for gradients
+    masked_gates = torch.softmax(masked_gates, dim=-1)
+    multiplier_o = masked_gates.gather(dim=-1, index=selected_experts)
 
-    mask_logits_threshold, selected_experts = torch.topk(scores, 2)
+    multiplier = multiplier_o
 
-    ################ first expert gating ################
+    # masked out first expert 
+    masked_scores = torch.scatter(
+        scores,
+        -1,
+        selected_experts,
+        float('-inf'),
+    )
+    with torch.no_grad():
+        # compute mask for sparsity
+        mask_logits_threshold, max_ind = masked_scores.max(dim=-1, keepdim=True)
+        factor = scores.abs().clamp(min=mask_logits_threshold)
+        mask_logits_threshold = (
+            (mask_logits_threshold - scores) / factor
+        ) > (2 * jitter_eps)
 
-    mask_logits_threshold_1 = mask_logits_threshold[:, 0].unsqueeze(-1)
+    # apply mask 
+    masked_gates_top2 = masked_scores.masked_fill(mask_logits_threshold, float('-inf'))
+    selected_experts_top2 = max_ind
+    # compute scores for gradients
+    masked_gates_top2 = torch.softmax(masked_gates_top2, dim=-1)
+    multiplier_top2 = masked_gates_top2.gather(dim=-1, index=selected_experts_top2)
 
-    factor = scores.abs().clamp(min=mask_logits_threshold_1)
-    logits_mask = (
-        (mask_logits_threshold_1 - scores) / factor
-    ) > (2 * jitter_eps)
-
-    multiplier_1 = torch.softmax(
-      scores.masked_fill(logits_mask, float('-inf')), dim=-1
-    ).gather(dim=-1, index=selected_experts[:, 0].unsqueeze(-1))
-
-    ################ second expert gating ################
-
-    mask_logits_threshold_2 = mask_logits_threshold[:, 1].unsqueeze(-1)
-
-    factor = scores.abs().clamp(min=mask_logits_threshold_2)
-    logits_mask = (
-        (mask_logits_threshold_2 - scores) / factor
-    ) > (2 * jitter_eps)
-
-    multiplier_2 = torch.softmax(
-      torch.scatter(
-        scores, -1, selected_experts[:, 0].unsqueeze(-1), float('-inf')
-      ).masked_fill(
-        logits_mask, float('-inf')
-      ), 
-      dim=-1
-    ).gather(dim=-1, index=selected_experts[:, 1].unsqueeze(-1))
-
-    multiplier = torch.concat((multiplier_1, multiplier_2), dim=-1)
+    multiplier = torch.concat((multiplier, multiplier_top2), dim=-1)
+    selected_experts = torch.concat((selected_experts, selected_experts_top2), dim=-1)
+    
     return (
         multiplier, 
         selected_experts,

--- a/vllm/model_executor/models/phimoe.py
+++ b/vllm/model_executor/models/phimoe.py
@@ -445,8 +445,7 @@ class PhiMoEAttention(nn.Module):
     ) -> torch.Tensor:
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
-        max_seq_tokens_tensor = attn_metadata.max_seq_tokens_tensor
-        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=max_seq_tokens_tensor)
+        q, k = self.rotary_emb(positions, q, k, max_seq_tokens_tensor=attn_metadata.max_seq_tokens_tensor)
         attn_output = self.attn(q, k, v, kv_cache, attn_metadata)
         output, _ = self.o_proj(attn_output)
         return output

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -297,8 +297,8 @@ class ModelRunner:
             # is always the first token in the sequence.
             input_positions.extend(list(range(computed_len, prefill_end)))
 
-            max_seq_tokens_list.append(prompt_len)
-            print(f"_prepare_prompt max_seq_tokens_list[0]: {max_seq_tokens_list[0]}")
+            for i in range(computed_len, prefill_end):
+                max_seq_tokens_list.append(prompt_len)
 
             lora_id = seq_group_metadata.lora_int_id
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -404,7 +404,7 @@ class ModelRunner:
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=True,
             prompt_lens=prompt_lens,
-            max_seq_tokens_list=max_seq_tokens_list,
+            max_seq_tokens_tensor=torch.tensor(max_seq_tokens_list).long().to(self.device),
             prompt_lens_tensor=prompt_lens_tensor,
             max_subquery_len=max_subquery_len,
             max_context_len=None,
@@ -540,7 +540,7 @@ class ModelRunner:
         attn_metadata = self.attn_backend.make_metadata(
             is_prompt=False,
             prompt_lens=None,
-            max_seq_tokens_list=max_seq_tokens_list,
+            max_seq_tokens_tensor=torch.tensor(max_seq_tokens_list).long().to(self.device),
             prompt_lens_tensor=None,
             max_subquery_len=None,
             max_context_len=max_context_len,
@@ -925,7 +925,7 @@ class ModelRunner:
                     is_prompt=False,
                     prompt_lens=None,
                     prompt_lens_tensor=None,
-                    max_seq_tokens_list= [0] * batch_size,
+                    max_seq_tokens_tensor= torch.tensor([0] * batch_size).long().cuda(),
                     max_subquery_len=None,
                     max_context_len=self.max_context_len_to_capture,
                     max_prompt_len=None,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -925,7 +925,7 @@ class ModelRunner:
                     is_prompt=False,
                     prompt_lens=None,
                     prompt_lens_tensor=None,
-                    max_seq_tokens_list=[],
+                    max_seq_tokens_list= [0] * batch_size,
                     max_subquery_len=None,
                     max_context_len=self.max_context_len_to_capture,
                     max_prompt_len=None,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -925,7 +925,7 @@ class ModelRunner:
                     is_prompt=False,
                     prompt_lens=None,
                     prompt_lens_tensor=None,
-                    max_seq_tokens_list=None,
+                    max_seq_tokens_list=[],
                     max_subquery_len=None,
                     max_context_len=self.max_context_len_to_capture,
                     max_prompt_len=None,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -728,6 +728,7 @@ class ModelRunner:
             num_decode_tokens=num_decode_tokens,
             prefill_metadata=prefill_attn_metadata,
             decode_metadata=decode_attn_metadata,
+            max_seq_tokens_tensor=max_seq_tokens_tensor,
             kv_cache_dtype=self.kv_cache_dtype,
         )
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -298,6 +298,7 @@ class ModelRunner:
             input_positions.extend(list(range(computed_len, prefill_end)))
 
             max_seq_tokens_list.append(prompt_len)
+            print(f"_prepare_prompt max_seq_tokens_list[0]: {max_seq_tokens_list[0]}")
 
             lora_id = seq_group_metadata.lora_int_id
 
@@ -457,6 +458,7 @@ class ModelRunner:
                 generation_token = seq_data.get_last_token_id()
                 input_tokens.append(generation_token)
                 max_seq_tokens_list.append(seq_data.get_prompt_len())
+                print(f"_prepare_decode max_seq_tokens_list[0]: {max_seq_tokens_list[0]}")
 
                 seq_len = seq_data.get_len()
                 position = seq_len - 1

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -711,6 +711,15 @@ class ModelRunner:
                 metadata_dict = broadcast_tensor_dict(src=0)
                 decode_attn_metadata = self.attn_backend.make_metadata(
                     **metadata_dict)
+                
+        if prefill_attn_metadata is not None:
+            max_seq_tokens_tensor = prefill_attn_metadata.max_seq_tokens_tensor
+            if decode_attn_metadata is not None:
+                max_seq_tokens_tensor = torch.cat(
+                    [max_seq_tokens_tensor, decode_attn_metadata.max_seq_tokens_tensor],
+                )
+        else:
+            max_seq_tokens_tensor = decode_attn_metadata.max_seq_tokens_tensor
 
         attn_metadata = AttentionMetadata(
             num_prefills=num_prefills,
@@ -942,6 +951,7 @@ class ModelRunner:
                     slot_mapping=slot_mapping[:batch_size],
                     prefill_metadata=None,
                     decode_metadata=decode_metadata,
+                    max_seq_tokens_tensor=decode_metadata.max_seq_tokens_tensor,
                     kv_cache_dtype=self.kv_cache_dtype,
                 )
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -266,10 +266,6 @@ class ModelRunner:
             prompt_tokens = seq_data.get_token_ids()[computed_len:prefill_end]
             prompt_len = prefill_end
             prompt_lens.append(prompt_len)
-            if seq_group_metadata.sampling_params.max_tokens is not None:
-                max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + prompt_len)
-            else:
-                max_seq_tokens_list.append(self.model_config.max_model_len)
 
             # NOTE: This only works for oooooooxxx style attention.
             if computed_block_nums is not None and len(
@@ -300,6 +296,13 @@ class ModelRunner:
             # NOTE(woosuk): Here we assume that the first token in the prompt
             # is always the first token in the sequence.
             input_positions.extend(list(range(computed_len, prefill_end)))
+
+            for _ in range(computed_len, prefill_end):
+                if seq_group_metadata.sampling_params.max_tokens is not None:
+                    max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + prompt_len)
+                else:
+                    max_seq_tokens_list.append(self.model_config.max_model_len)
+
             lora_id = seq_group_metadata.lora_int_id
 
             if lora_id > 0:

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -297,11 +297,7 @@ class ModelRunner:
             # is always the first token in the sequence.
             input_positions.extend(list(range(computed_len, prefill_end)))
 
-            for _ in range(computed_len, prefill_end):
-                if seq_group_metadata.sampling_params.max_tokens is not None:
-                    max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + prompt_len)
-                else:
-                    max_seq_tokens_list.append(self.model_config.max_model_len)
+            max_seq_tokens_list.append(prompt_len)
 
             lora_id = seq_group_metadata.lora_int_id
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -460,10 +460,7 @@ class ModelRunner:
                 seq_data = seq_group_metadata.seq_data[seq_id]
                 generation_token = seq_data.get_last_token_id()
                 input_tokens.append(generation_token)
-                if seq_group_metadata.sampling_params.max_tokens is not None:
-                    max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + seq_data.get_prompt_len())
-                else:
-                    max_seq_tokens_list.append(self.model_config.max_model_len)
+                max_seq_tokens_list.append(seq_data.get_prompt_len())
 
                 seq_len = seq_data.get_len()
                 position = seq_len - 1

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -1054,6 +1054,7 @@ class CUDAGraphRunner:
             "slot_mapping": attn_metadata.slot_mapping,
             "context_lens": attn_metadata.decode_metadata.context_lens,
             "block_tables": attn_metadata.decode_metadata.block_tables,
+            "max_seq_tokens_tensor": attn_metadata.max_seq_tokens_tensor,
         }
         self.output_buffers = {"hidden_states": hidden_states}
         return
@@ -1078,6 +1079,8 @@ class CUDAGraphRunner:
             attn_metadata.decode_metadata.context_lens, non_blocking=True)
         self.input_buffers["block_tables"].copy_(
             attn_metadata.decode_metadata.block_tables, non_blocking=True)
+        self.input_buffers["max_seq_tokens_tensor"].copy_(
+            attn_metadata.max_seq_tokens_tensor, non_blocking=True)
         # Run the graph.
         self.graph.replay()
 

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -925,6 +925,7 @@ class ModelRunner:
                     is_prompt=False,
                     prompt_lens=None,
                     prompt_lens_tensor=None,
+                    max_seq_tokens_list=None,
                     max_subquery_len=None,
                     max_context_len=self.max_context_len_to_capture,
                     max_prompt_len=None,

--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -266,7 +266,10 @@ class ModelRunner:
             prompt_tokens = seq_data.get_token_ids()[computed_len:prefill_end]
             prompt_len = prefill_end
             prompt_lens.append(prompt_len)
-            max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + prompt_len)
+            if seq_group_metadata.sampling_params.max_tokens is not None:
+                max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + prompt_len)
+            else:
+                max_seq_tokens_list.append(self.model_config.max_model_len)
 
             # NOTE: This only works for oooooooxxx style attention.
             if computed_block_nums is not None and len(
@@ -454,7 +457,10 @@ class ModelRunner:
                 seq_data = seq_group_metadata.seq_data[seq_id]
                 generation_token = seq_data.get_last_token_id()
                 input_tokens.append(generation_token)
-                max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + seq_data.get_prompt_len())
+                if seq_group_metadata.sampling_params.max_tokens is not None:
+                    max_seq_tokens_list.append(seq_group_metadata.sampling_params.max_tokens + seq_data.get_prompt_len())
+                else:
+                    max_seq_tokens_list.append(self.model_config.max_model_len)
 
                 seq_len = seq_data.get_len()
                 position = seq_len - 1


### PR DESCRIPTION
## Issue

Before this fix: if we start from a prompt with length < 4K but the total sequence length will >4K after generation, the generated tokens after 4K will be gabage.

## Root Cause

LongRoPE uses difference scaling factors for <=4k / > 4k sequences. When the generation comes across the switch point of 4K, the kv cache of prefill tokens are calculated based on short factors, but the new tokens are generated based on long factors. This inconsistency leads to the generation crash.

## Solution

Pass `prompt_length + max_generation_tokens` to the model.
If it is larger than 4K, we should use the long factors for all calculations of this sequence.