### PR TITLE
Fix Padding Issue When Using Captured Cuda Graph

### DIFF
--- a/vllm/worker/model_runner.py
+++ b/vllm/worker/model_runner.py
@@ -502,6 +502,7 @@ class ModelRunner:
             for _ in range(graph_batch_size - batch_size):
                 input_tokens.append(0)
                 input_positions.append(0)
+                max_seq_tokens_list.append(0)
                 slot_mapping.append(_PAD_SLOT_ID)
                 context_lens.append(1)
                 block_tables.append([])


### PR DESCRIPTION
Error message:
```
ERROR 08-08 01:05:23 worker_base.py:147] Error executing method execute_model. This might cause deadlock in distributed execution.
ERROR 08-08 01:05:23 worker_base.py:147] Traceback (most recent call last):
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 139, in execute_method
ERROR 08-08 01:05:23 worker_base.py:147]     return executor(*args, **kwargs)
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
ERROR 08-08 01:05:23 worker_base.py:147]     return func(*args, **kwargs)
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker.py", line 249, in execute_model
ERROR 08-08 01:05:23 worker_base.py:147]     output = self.model_runner.execute_model(seq_group_metadata_list,
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
ERROR 08-08 01:05:23 worker_base.py:147]     return func(*args, **kwargs)
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 768, in execute_model
ERROR 08-08 01:05:23 worker_base.py:147]     hidden_states = model_executable(**execute_model_kwargs)
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1091, in __call__
ERROR 08-08 01:05:23 worker_base.py:147]     return self.forward(*args, **kwargs)
ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1082, in forward
ERROR 08-08 01:05:23 worker_base.py:147]     self.input_buffers["max_seq_tokens_tensor"].copy_(
ERROR 08-08 01:05:23 worker_base.py:147] RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
ERROR 08-08 01:05:23 async_llm_engine.py:43] Engine background task failed
ERROR 08-08 01:05:23 async_llm_engine.py:43] Traceback (most recent call last):
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 38, in _raise_exception_on_finish
ERROR 08-08 01:05:23 async_llm_engine.py:43]     task.result()
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 496, in run_engine_loop
ERROR 08-08 01:05:23 async_llm_engine.py:43]     has_requests_in_progress = await asyncio.wait_for(
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/usr/lib/python3.10/asyncio/tasks.py", line 445, in wait_for
ERROR 08-08 01:05:23 async_llm_engine.py:43]     return fut.result()
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 470, in engine_step
ERROR 08-08 01:05:23 async_llm_engine.py:43]     request_outputs = await self.engine.step_async()
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/engine/async_llm_engine.py", line 213, in step_async
ERROR 08-08 01:05:23 async_llm_engine.py:43]     output = await self.model_executor.execute_model_async(
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/executor/distributed_gpu_executor.py", line 110, in execute_model_async
ERROR 08-08 01:05:23 async_llm_engine.py:43]     all_outputs = await self._run_workers_async("execute_model",
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/executor/ray_gpu_executor.py", line 352, in _run_workers_async
ERROR 08-08 01:05:23 async_llm_engine.py:43]     all_outputs = await asyncio.gather(*coros)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
ERROR 08-08 01:05:23 async_llm_engine.py:43]     result = self.fn(*self.args, **self.kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 148, in execute_method
ERROR 08-08 01:05:23 async_llm_engine.py:43]     raise e
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 139, in execute_method
ERROR 08-08 01:05:23 async_llm_engine.py:43]     return executor(*args, **kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
ERROR 08-08 01:05:23 async_llm_engine.py:43]     return func(*args, **kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker.py", line 249, in execute_model
ERROR 08-08 01:05:23 async_llm_engine.py:43]     output = self.model_runner.execute_model(seq_group_metadata_list,
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
ERROR 08-08 01:05:23 async_llm_engine.py:43]     return func(*args, **kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 768, in execute_model
ERROR 08-08 01:05:23 async_llm_engine.py:43]     hidden_states = model_executable(**execute_model_kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1091, in __call__
ERROR 08-08 01:05:23 async_llm_engine.py:43]     return self.forward(*args, **kwargs)
ERROR 08-08 01:05:23 async_llm_engine.py:43]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1082, in forward
ERROR 08-08 01:05:23 async_llm_engine.py:43]     self.input_buffers["max_seq_tokens_tensor"].copy_(
ERROR 08-08 01:05:23 async_llm_engine.py:43] RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
INFO 08-08 01:05:23 async_llm_engine.py:154] Aborted request 8e345093931645ff9057a8725048eb1a.
INFO 08-08 01:05:23 async_llm_engine.py:154] Aborted request 3ff3981fc1954273840e277485787b43.
INFO 08-08 01:05:23 async_llm_engine.py:154] Aborted request 27a85be4e5a044f5a558ff9fa24c2ffa.
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147] Error executing method execute_model. This might cause deadlock in distributed execution.
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147] Traceback (most recent call last):
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 139, in execute_method
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     return executor(*args, **kwargs)
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     return func(*args, **kwargs)
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/worker.py", line 249, in execute_model
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     output = self.model_runner.execute_model(seq_group_metadata_list,
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     return func(*args, **kwargs)
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 768, in execute_model
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     hidden_states = model_executable(**execute_model_kwargs)
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1091, in __call__
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     return self.forward(*args, **kwargs)
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]   File "/home/phi3user/.local/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1082, in forward
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147]     self.input_buffers["max_seq_tokens_tensor"].copy_(
[36m(RayWorkerWrapper pid=186241)[0m ERROR 08-08 01:05:23 worker_base.py:147] RuntimeError: The size of tensor a (4) must match the size of tensor b (3) at non-singleton dimension 0
```